### PR TITLE
fix: add missing Babel configuration and .gitignore to resolve build errors

### DIFF
--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-react",
+    "@babel/preset-typescript"
+  ]
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,24 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
### Summary
This PR adds the missing Babel configuration (`.babelrc`) and a `.gitignore` file to resolve issue encountered during the build. The missing Babel setup led to syntax parsing errors, specifically the _Missing initializer in const declaration error_ when using TypeScript with React. 

### Changes
- Added `.babelrc` for correct TypeScript parsing with Babel
- Included a `.gitignore` file to ignore node modules, environment files, and other untracked files

### Linked Issue
Fixes #7 
